### PR TITLE
Fix broken @seldridge website link

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
       Krieger</a></br>
   	  <a href="http://www.cs.bu.edu/~homer/">Steve Homer</a></br>
 	  <a href="http://www.bu.edu/ece/people/faculty/h-n/ajay-joshi/">Ajay Joshi</a></br>
-	  <a href="http://people.bu.edu/schuye/">Schuyler Eldridge</a></br> 
+	  <a href="https://seldridge.github.io/">Schuyler Eldridge</a></br>
 	  </dd>
 	</dd>
 	<dt style="font-size:24px">Undergraduates</dt>


### PR DESCRIPTION
BU finally scrubbed my people.bu.edu site... This updates the link to a
stable GitHub pages link.